### PR TITLE
Fixed AppStream metadata

### DIFF
--- a/install_scripts/environment/desktop/QXmlEdit.appdata.xml
+++ b/install_scripts/environment/desktop/QXmlEdit.appdata.xml
@@ -24,7 +24,9 @@
     <url type="homepage">https://qxmledit.org</url>
     <url type="bugtracker">https://github.com/lbellonda/qxmledit/issues</url>
     <releases>
-      <release version="0.9.18" />
+      <release version="0.9.18" date="2023-01-30" />
+      <release version="0.9.17" date="2022-04-02" />
+      <release version="0.9.16" date="2020-09-12" />
     </releases>
     <project_group>Qt</project_group>
     <content_rating type="oars-1.1" />

--- a/install_scripts/environment/desktop/QXmlEdit.appdata.xml
+++ b/install_scripts/environment/desktop/QXmlEdit.appdata.xml
@@ -14,7 +14,7 @@
     <launchable type="desktop-id">QXmlEdit.desktop</launchable>
     <screenshots>
         <screenshot type="default">
-            <image width="800" height="600">https://raw.githubusercontent.com/lbellonda/qxmledit/master/install_scripts/environment/desktop/screenshots/qxmledit800.png</image>
+            <image>https://raw.githubusercontent.com/lbellonda/qxmledit/master/install_scripts/environment/desktop/screenshots/qxmledit800.png</image>
         </screenshot>
     </screenshots>
     <categories>

--- a/install_scripts/environment/desktop/QXmlEdit.appdata.xml
+++ b/install_scripts/environment/desktop/QXmlEdit.appdata.xml
@@ -18,8 +18,6 @@
         </screenshot>
     </screenshots>
     <categories>
-    ​    <category>Utility</category>
-        <category>Qt</category>
         <category>Development</category>
         <category>TextEditor</category>
     ​</categories>
@@ -28,11 +26,5 @@
     <releases>
       <release version="0.9.18" />
     </releases>
-    <provides>
-   ​    <binary>qxmledit</binary>
-   ​  </provides>
-    <mimetypes>
-    ​    <mimetype>text/xml</mimetype>
-    ​ </mimetypes>
     <project_group>Qt</project_group>
 </component>

--- a/install_scripts/environment/desktop/QXmlEdit.appdata.xml
+++ b/install_scripts/environment/desktop/QXmlEdit.appdata.xml
@@ -27,4 +27,5 @@
       <release version="0.9.18" />
     </releases>
     <project_group>Qt</project_group>
+    <content_rating type="oars-1.1" />
 </component>

--- a/install_scripts/environment/desktop/QXmlEdit.appdata.xml
+++ b/install_scripts/environment/desktop/QXmlEdit.appdata.xml
@@ -6,6 +6,9 @@
     <project_license>LGPL-2.0+</project_license>
     <name>QXmlEdit</name>
     <summary>XML editor</summary>
+    <developer id="org.qxmledit">
+        <name>QXmlEdit Developers</name>
+    </developer>
     <description>
         <p>
             QXmlEdit is an XML editor with some facilities to explore and process big files.

--- a/install_scripts/environment/desktop/QXmlEdit.appdata.xml
+++ b/install_scripts/environment/desktop/QXmlEdit.appdata.xml
@@ -24,6 +24,7 @@
     <url type="homepage">https://qxmledit.org</url>
     <url type="bugtracker">https://github.com/lbellonda/qxmledit/issues</url>
     <releases>
+      <release version="0.9.18.1" date="2026-05-22" />
       <release version="0.9.18" date="2023-01-30" />
       <release version="0.9.17" date="2022-04-02" />
       <release version="0.9.16" date="2020-09-12" />

--- a/install_scripts/environment/desktop/QXmlEdit.appdata.xml
+++ b/install_scripts/environment/desktop/QXmlEdit.appdata.xml
@@ -22,6 +22,7 @@
         <category>TextEditor</category>
     ​</categories>
     <url type="homepage">https://qxmledit.org</url>
+    <url type="vcs-browser">https://github.com/lbellonda/qxmledit/</url>
     <url type="bugtracker">https://github.com/lbellonda/qxmledit/issues</url>
     <releases>
       <release version="0.9.18.1" date="2026-05-22" />


### PR DESCRIPTION
Flatpak builder complained about it. I think it does not like multiple primary categories and the other fields also threw errors. I guess https://freedesktop.org/software/appstream/docs/chap-Metadata.html moved on and this wasn't updated.